### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: CI - Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/yveskaufmann/retry/security/code-scanning/2](https://github.com/yveskaufmann/retry/security/code-scanning/2)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. This is best done at the workflow (root) level so it applies to all jobs, unless a job needs different permissions. Since this CI workflow only checks out code, installs dependencies, builds, lints, tests, and uploads coverage, it should only need read access to repository contents. No write access or extra scopes (like `pull-requests: write`) appear necessary.

The single best fix without changing functionality is:
- Add a `permissions:` block at the root level (same indentation as `on:` and `jobs:`) specifying `contents: read`.
- This ensures the token is restricted, documents the workflow’s needs, and satisfies CodeQL’s recommendation.

Concretely, in `.github/workflows/ci.yml`:
- Insert after the `name: CI - Workflow` line:

```yaml
permissions:
  contents: read
```

No other steps, jobs, or actions need modification, and no imports or methods are required since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
