### PR TITLE
chore: drop Node.js 18 (EOL), add 22 and 24 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

Node.js 18 reached **End-of-Life in April 2025** and is no longer receiving security updates. This PR updates the CI build matrix to drop 18 and test against all currently supported LTS versions.

### Change

```diff
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
```

| Version | Status |
|---|---|
| ~~18.x~~ | End-of-Life (April 2025) — removed |
| 20.x | Active LTS ✅ |
| 22.x | Active LTS ✅ |
| 24.x | Current / upcoming LTS ✅ |