### PR TITLE
chore: declare supported Node.js versions via engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "author": "Yves Kaufmann",
   "license": "MIT",
+  "engines": {
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+  },
   "bugs": {
     "url": "https://github.com/yveskaufmann/retry/issues"
   },


### PR DESCRIPTION
## Summary

Adds an `engines` field to `package.json` to declare the supported Node.js versions.

## Motivation

PR #131 updated the CI matrix to test against Node.js 20, 22, and 24 (dropping EOL Node.js 18). However, `package.json` had no `engines` field, so there was no declared support range. This PR aligns the declared engines with the CI matrix.

## Change

```json
"engines": {
  "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
}
```

Node.js 18 reached EOL in April 2025 and is no longer tested in CI.